### PR TITLE
M1's now available on CodeMagic

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -86,3 +86,6 @@ app:
     - opts:
         is_expand: false
       BITRISE_EXPORT_METHOD: development
+meta:
+  bitrise.io:
+    stack: osx-xcode-13.4.x

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,7 +4,7 @@ workflows:
   react-native-ios:
     name: iOS Workflow
     max_build_duration: 60
-    instance_type: mac_mini
+    instance_type: mac_mini_m1
     environment:
       node: 16.13.2
       xcode: 13.2.1


### PR DESCRIPTION
- https://blog.codemagic.io/codemagic-mac-mini-m1-release/
- https://github.com/retyui/react-native-ci-cd-compare/issues/12