### PR TITLE
fix(CircleCI IOS): Fix working_directory path and update Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,15 @@ jobs:
             - node_modules
 
   ios-build:
-    working_directory: ~/app/android
+    working_directory: ~/app/ios
     macos:
-      xcode: 11.3.0
+      xcode: 13.4.1
 
     steps:
       - checkout:
           path: ~/app
       - attach_workspace:
           at: ~/app
-      - run: yarn install --frozen-lockfile
       - restore_cache:
           key: pods-v1-{{ checksum "ios/Podfile.lock" }}-{{ arch }}
       - run:


### PR DESCRIPTION
Fix the circleCI `ios-build` job's working director, and remove the command yarn install inside it since this job is requires the `node` job which indeed install the node dependencies 